### PR TITLE
handle dependency clash in Alpine repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ RUN apk add --no-cache \
       # Other dependencies
       ca-certificates \
       su-exec \
-      py3-pysocks
+      py3-pysocks \
+      # Explicit dependency with different repository
+      py3-python-editor@edge_community
 
 COPY requirements.txt /opt/mautrix-hangouts/requirements.txt
 COPY optional-requirements.txt /opt/mautrix-hangouts/optional-requirements.txt


### PR DESCRIPTION
I experienced a weird bug while building the image on my arm32 architecture. This change fixes it, by explicitly installing a py3-alembic dependency (py3-python-editor) from the community repo. The problem seems to be, that the two packages are in different repositories, so apk cannot resolve the dependency constraint.