### PR TITLE
prevent initial sync eventually going into infinte loop

### DIFF
--- a/mautrix_hangouts/portal.py
+++ b/mautrix_hangouts/portal.py
@@ -261,7 +261,7 @@ class Portal(BasePortal):
                                    message.id_, message.timestamp)
                     return messages
                 messages.append(message)
-            if len(chunk) < chunk_limit:
+            if len(chunk) <= chunk_limit:
                 return messages
             limit -= len(chunk)
 


### PR DESCRIPTION
Address #27 
The problem is that it will not stop when `chunk_limit=len(chunk)`, so if `chunk=0`, it goes into an infinite loop. Commit fixed it on my end. I'm not sure if it introduces other problems in edge cases. I didn't see one myself, yet I didn't gave it much thought.