### PR TITLE
Handle bad attachments.

### DIFF
--- a/mautrix_hangouts/portal.py
+++ b/mautrix_hangouts/portal.py
@@ -575,7 +575,10 @@ class Portal(BasePortal):
         if event.attachments:
             self.log.debug("Processing attachments.")
             self.log.trace("Attachments: %s", event.attachments)
-            event_id = await self.process_hangouts_attachments(event, intent)
+            try:
+                event_id = await self.process_hangouts_attachments(event, intent)
+            except:
+                event_id = None
         # Just to fallback to text if something else hasn't worked.
         if not event_id:
             content = TextMessageEventContent(msgtype=MessageType.TEXT, body=event.text)

--- a/mautrix_hangouts/portal.py
+++ b/mautrix_hangouts/portal.py
@@ -577,7 +577,8 @@ class Portal(BasePortal):
             self.log.trace("Attachments: %s", event.attachments)
             try:
                 event_id = await self.process_hangouts_attachments(event, intent)
-            except:
+            except Exception:
+                self.log.warning("Failed to process attachment", exc_info=True)
                 event_id = None
         # Just to fallback to text if something else hasn't worked.
         if not event_id:


### PR DESCRIPTION
mautrix-hangouts can fail during backfilling messages in various ways:

```
Traceback (most recent call last):
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix_hangouts/portal.py", line 272, in backfill
    await self._backfill(source, is_initial)
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix_hangouts/portal.py", line 294, in _backfill
    await self.handle_hangouts_message(source, puppet, message)
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix_hangouts/portal.py", line 578, in handle_hangouts_message
    event_id = await self.process_hangouts_attachments(event, intent)
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix_hangouts/portal.py", line 607, in process_hangouts_attachments
    value, params = cgi.parse_header(resp.headers["Content-Disposition"])
KeyError: 'Content-Disposition'
```

or

```
Traceback (most recent call last):
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix_hangouts/portal.py", line 272, in backfill
    await self._backfill(source, is_initial)
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix_hangouts/portal.py", line 294, in _backfill
    await self.handle_hangouts_message(source, puppet, message)
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix_hangouts/portal.py", line 578, in handle_hangouts_message
    event_id = await self.process_hangouts_attachments(event, intent)
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix_hangouts/portal.py", line 620, in process_hangouts_attachments
    mxc_url = await intent.upload_media(data, mime_type=upload_mime, filename=filename)
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix/appservice/api/intent.py", line 79, in wrapper
    return await __method(*args, **kwargs)
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix/client/api/modules/media_repository.py", line 58, in upload_media
    resp = await self.api.request(Method.POST, MediaPath.upload, content=data,
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix/api.py", line 208, in request
    return await self._send(method, endpoint, content, query_params, headers or {})
  File "/srv/mautrix-hangouts/lib/python3.8/site-packages/mautrix/api.py", line 147, in _send
    raise make_request_error(http_status=response.status,
mautrix.errors.request.MUnknown: Internal server error
```

This change catches the exception and ignores the attachment.