### PR TITLE
Add support for formatting in messages

### DIFF
--- a/mautrix_hangouts/user.py
+++ b/mautrix_hangouts/user.py
@@ -441,7 +441,7 @@ class User(BaseUser):
             request_header=self.client.get_request_header(),
             event_request_header=await self._get_event_request_header(conversation_id),
             message_content=hangouts.MessageContent(
-                segment=[hangups.ChatMessageSegment(text).serialize()],
+                segment=[segment.serialize() for segment in hangups.ChatMessageSegment.from_str(text)],
             ),
         ))
         return resp.created_event.event_id


### PR DESCRIPTION
Closes #9, closes #26

This basically is how the hangups client itself handles formatting. It supports `_italics_, **bold**, <del>strikethrough</del>, http://example.com/urls` and maybe something more.